### PR TITLE
Fix: Use bun in CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,17 +15,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
       
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
       
       - name: Build
-        run: npm run build
+        run: bun run build
       
       - name: Deploy to deployment branch
         uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32


### PR DESCRIPTION
The CI workflow was failing because it was using npm to install dependencies, but the project is configured to use bun. This resulted in a 'Dependencies lock file is not found' error.

This commit updates the CI workflow to use bun for installing dependencies and building the project. It replaces the `actions/setup-node` action with `oven-sh/setup-bun` and updates the relevant commands to use `bun` instead of `npm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline to use a faster build tool, improving install and build times.
  * Switched CI steps to align with the new tool for dependency installation and building.
  * Deployment behavior remains the same; no changes to app functionality.
  * No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->