### PR TITLE
Fix security vulnerability in @tootallnate/once (GHSA-vpq2-c234-7xj6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3038,9 +3038,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "lodash": "4.17.23",
     "ajv": "6.14.0",
     "minimatch": "10.2.4",
-    "rollup": "4.59.0"
+    "rollup": "4.59.0",
+    "@tootallnate/once": "3.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",


### PR DESCRIPTION
Updated the `@tootallnate/once` package to version `3.0.1` to resolve a security vulnerability (GHSA-vpq2-c234-7xj6). The update was applied using the `overrides` field in `package.json`, which is the recommended way to manage nested dependency versions in npm. The change was verified by running `npm audit`, `npm run lint`, `npm test`, and `npm run build`, all of which passed correctly.

---
*PR created automatically by Jules for task [12067529066172686269](https://jules.google.com/task/12067529066172686269) started by @sagolubev*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency override configuration with an additional package version pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->