### PR TITLE
Fix security vulnerability in flatted (Dependabot #24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5004,9 +5004,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "ajv": "6.14.0",
     "minimatch": "10.2.4",
     "rollup": "4.59.0",
-    "@tootallnate/once": "3.0.1"
+    "@tootallnate/once": "3.0.1",
+    "flatted": "3.4.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",


### PR DESCRIPTION
This PR addresses the security vulnerability in the `flatted` package (Dependabot alert #24). 
The vulnerability (CVE-2024-48911) is fixed by overriding the version of `flatted` to `3.4.2` in `package.json`.
The fix has been verified with `npm audit` which now reports 0 vulnerabilities, and the full CI suite (`npm ci`, `npm run lint`, `npm test`, `npm run build`) passed successfully.

---
*PR created automatically by Jules for task [10856152049599027963](https://jules.google.com/task/10856152049599027963) started by @sagolubev*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->