### PR TITLE
fix(deps): update undici to 7.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7932,9 +7932,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- update transitive dev dependency `undici` from 7.28.0 to 7.29.0
- resolve Dependabot alerts #45-#49
- keep the remediation lockfile-only because `jsdom@29.1.1` already permits the patched release

## Validation
- Node 24 / npm 11 `npm ci`
- `npm audit`: all five undici advisories removed
- `npm run lint`
- `npm test`: 50 passed
- `npm run build`
- canonical `npm update undici --package-lock-only`
- production assets byte-identical to current deployment