### PR TITLE
fix(ci): bound deploy package installs

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: aks-self-hosted
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -47,6 +48,7 @@ jobs:
 
       - name: Install deploy prerequisites
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        timeout-minutes: 3
         run: |
           if command -v rsync >/dev/null 2>&1; then
             exit 0
@@ -59,8 +61,9 @@ jobs:
           fi
 
           if command -v apt-get >/dev/null 2>&1; then
-            $SUDO apt-get update
-            $SUDO apt-get install -y rsync
+            APT_OPTIONS=(-o Acquire::ForceIPv4=true -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15)
+            $SUDO apt-get "${APT_OPTIONS[@]}" update
+            $SUDO apt-get "${APT_OPTIONS[@]}" install -y rsync
           elif command -v apk >/dev/null 2>&1; then
             $SUDO apk add --no-cache rsync
           else


### PR DESCRIPTION
## Summary
- cap the deploy job and package-install step runtime
- force apt IPv4 with bounded connection timeouts and retries
- prevent Ubuntu archive outages from hanging Pages deployment indefinitely

## Evidence
- exact runner for deployment run 30924124714 has `apt-get update` stuck for more than 10 minutes
- IPv4 TCP to archive.ubuntu.com timed out from that runner
- actionlint passed with the known `aks-self-hosted` custom-label exception
- npm lint passed with existing warnings only
- 50 tests passed
- production build passed