### PR TITLE
fix(ci): use HTTPS for Ubuntu apt sources

### DIFF
--- a/.github/workflows/ci-cd-deployment.yml
+++ b/.github/workflows/ci-cd-deployment.yml
@@ -61,6 +61,14 @@ jobs:
           fi
 
           if command -v apt-get >/dev/null 2>&1; then
+            for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+              if [ -f "$source_file" ]; then
+                $SUDO sed -i \
+                  -e 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                  -e 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' \
+                  "$source_file"
+              fi
+            done
             APT_OPTIONS=(-o Acquire::ForceIPv4=true -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15)
             $SUDO apt-get "${APT_OPTIONS[@]}" update
             $SUDO apt-get "${APT_OPTIONS[@]}" install -y rsync


### PR DESCRIPTION
## Summary
- rewrite canonical Ubuntu archive and security source URIs from HTTP to HTTPS before apt update
- retain the existing IPv4, retry, and timeout bounds

## Evidence
- exact successor run `30926412115` timed out after 3 minutes because HTTP connections to `archive.ubuntu.com:80` and `security.ubuntu.com:80` failed
- same ARC pool returned HTTP 200 for both HTTPS InRelease endpoints
- exact rewrite was dry-run against `/etc/apt/sources.list.d/ubuntu.sources` on the ARC pool and produced the expected HTTPS URIs
- actionlint has no errors beyond the known custom `aks-self-hosted` label warning
- `git diff --check` passes